### PR TITLE
Avoid possible unintended misleading ReadMe in forks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 libcellml
 =========
 
-This is the primary repository for the development of libCellML
+libCellML aims to become an easy to use library that will be useful to developers of CellML applications.
+It will replace the legacy `CellML-API <http://cellml-api.sourceforge.net/>`_ .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 libcellml
 =========
-
 libCellML aims to become an easy to use library that will be useful to developers of CellML applications.
 It will replace the legacy `CellML-API <http://cellml-api.sourceforge.net/>`_ .
+
+The main libCellML repository is located at: https://github.com/cellml/libcellml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 libcellml
 =========
 libCellML aims to become an easy to use library that will be useful to developers of CellML applications.
-It will replace the legacy `CellML-API <http://cellml-api.sourceforge.net/>`_ .
+It will replace the legacy CellML-API (see http://cellml-api.sourceforge.net/) .
 
 The main libCellML repository is located at: https://github.com/cellml/libcellml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 libcellml
 =========
 libCellML aims to become an easy to use library that will be useful to developers of CellML applications.
-It will replace the legacy CellML-API (see http://cellml-api.sourceforge.net/) .
+It will replace the legacy [CellML-API](http://cellml-api.sourceforge.net/).
 
-The main libCellML repository is located at: https://github.com/cellml/libcellml
+The main libCellML repository is located at: https://github.com/cellml/libcellml, please make sure you are not unintentionally browsing a fork of the main repository.


### PR DESCRIPTION
The current ReadMe means all forks display "This is the primary repository for the development of libCellML" by default, which could lead to confusion.
